### PR TITLE
[Dependency bump] Bump cdap and hadoop versions to resolve vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
     <app.parents>system:cdap-data-pipeline[4.0.0,7.0.0),system:cdap-data-streams[4.0.0,7.0.0)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hadoop.version>2.3.0</hadoop.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
@@ -289,7 +289,7 @@
     <!-- tests -->
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -408,8 +408,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
     <app.parents>system:cdap-data-pipeline[4.0.0,7.0.0),system:cdap-data-streams[4.0.0,7.0.0)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
-    <cdap.version>6.8.0</cdap.version>
-    <hadoop.version>2.10.2</hadoop.version>
+    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
+    <hadoop.version>2.3.0</hadoop.version>
     <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
@@ -77,7 +77,7 @@
     <google-analytics-v3.version>v3-rev161-1.25.0</google-analytics-v3.version>
     <google-http-client-gson.version>1.32.1</google-http-client-gson.version>
   </properties>
-  
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -236,6 +236,10 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
@@ -289,7 +293,7 @@
     <!-- tests -->
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline2_2.11</artifactId>
+      <artifactId>cdap-data-pipeline</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -408,8 +412,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
Hadoop version 2.3.0 has transitive dependency on log4j 1.2.17 which has vulnerabilities. This PR is to resolve the vulnerabilities by bumping hadoop to version 2.10.2 and also update cdap version to the latest version.

Maven build and all unit tests succeeded.

