### PR TITLE
Fix security vulnerability in log4j(reverting previous pr changes) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,9 +67,9 @@
     <app.parents>system:cdap-data-pipeline[4.0.0,7.0.0),system:cdap-data-streams[4.0.0,7.0.0)</app.parents>
     <!-- this is here because project.basedir evaluates to null in the script build step -->
     <main.basedir>${project.basedir}</main.basedir>
-    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
-    <hadoop.version>2.3.0</hadoop.version>
-    <hydrator.version>2.3.0-SNAPSHOT</hydrator.version>
+    <cdap.version>6.8.0</cdap.version>
+    <hadoop.version>2.10.2</hadoop.version>
+    <hydrator.version>2.10.0</hydrator.version>
     <junit.version>4.11</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <spark.version>2.3.1</spark.version>
@@ -236,10 +236,6 @@
       <scope>provided</scope>
       <exclusions>
         <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-log4j12</artifactId>
         </exclusion>
@@ -293,7 +289,7 @@
     <!-- tests -->
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-data-pipeline</artifactId>
+      <artifactId>cdap-data-pipeline2_2.11</artifactId>
       <version>${cdap.version}</version>
       <scope>test</scope>
     </dependency>
@@ -412,8 +408,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.8.0,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.8.0,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
Change Description

Fixed security vulnerability for dependencies:

log4j
Changes:

Previous PR resolved this issue by excluding the log4j dependency. But bumping hadoop version is a better solution.reverting the changes.
Verification

Verified version override using mvn dependency:tree